### PR TITLE
Added Calendar event duration change by drag.

### DIFF
--- a/Frontend/src/components/Calendar/StudentCalendar.js
+++ b/Frontend/src/components/Calendar/StudentCalendar.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
+import 'react-big-calendar/lib/addons/dragAndDrop/styles.css';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
@@ -82,6 +83,18 @@ function StudentCalendar() {
     });
   }
 
+  function resizeEvent({ event, start, end }) {
+    setAllEvents((prevEvents) => {
+      const updatedEvents = prevEvents.map((ev) => {
+        if (ev.id === event.id) {
+          return { ...ev, start, end };
+        }
+        return ev;
+      });
+      return updatedEvents;
+    });
+  }
+
   return (
     <div>
       <div id="container">
@@ -128,6 +141,8 @@ function StudentCalendar() {
               startAccessor="start"
               endAccessor="end"
               onEventDrop={moveEvent}
+              resizable={true} // Enable event resizing
+              onEventResize={resizeEvent} // Handle event resizing
               onSelectSlot={({ start, end }) => {
                 const title = window.prompt('Enter event title:');
                 if (title) {


### PR DESCRIPTION
-Added a feature in `react-big-calendar` which allows admins to change the event duration by dragging the edge of the event in the calendar itself.

![SkillScape - Google Chrome 2023-05-19 17-55-02](https://github.com/kalviumcommunity/SkillScape/assets/113344554/72f1b6dc-612b-4e1a-ae40-e13b98807289)
